### PR TITLE
Rename as_string to inspect_value

### DIFF
--- a/lib/wuunder_utils/strings.ex
+++ b/lib/wuunder_utils/strings.ex
@@ -137,16 +137,19 @@ defmodule WuunderUtils.Strings do
 
   ## Examples
 
-      iex> WuunderUtils.Strings.as_string("this is a string")
+      iex> WuunderUtils.Strings.inspect_value("this is a string")
       "this is a string"
 
-      iex> WuunderUtils.Strings.as_string(%{a: 10})
+      iex> "This is " <> WuunderUtils.Strings.inspect_value("a string")
+      "This is a string"
+
+      iex> WuunderUtils.Strings.inspect_value(%{a: 10})
       "%{a: 10}"
 
   """
-  @spec as_string(any()) :: String.t()
-  def as_string(value) when is_binary(value), do: value
-  def as_string(value), do: inspect(value)
+  @spec inspect_value(any()) :: String.t()
+  def inspect_value(value) when is_binary(value), do: value
+  def inspect_value(value), do: inspect(value)
 
   @doc """
   Truncates a string with a given string. If string is longer than

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule WuunderUtils.MixProject do
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test, "coveralls.html": :test],
-      version: "0.2.6"
+      version: "0.2.7"
     ]
   end
 


### PR DESCRIPTION
As discussed in https://github.com/wuunder/takusan/pull/381
The goal is to `inspect` a string or other value. Basically used for logging. So I was thinking: maybe rename this to `inspect_value` ?

Other suggestions:
- pry
- print

* [x] Review required
* [x] Includes 1+ tests
* [x] Fully tested locally

