### PR TITLE
Use decimals as numbers.to_string/1

### DIFF
--- a/lib/wuunder_utils/numbers.ex
+++ b/lib/wuunder_utils/numbers.ex
@@ -149,8 +149,8 @@ defmodule WuunderUtils.Numbers do
 
   ## Examples
 
-      iex> WuunderUtils.Numbers.as_string(13.37)
-      "13.37"
+      iex> WuunderUtils.Numbers.as_string(3200.00)
+      "3200.0"
 
       iex> WuunderUtils.Numbers.as_string(Decimal.new("13.37"))
       "13.37"
@@ -169,7 +169,10 @@ defmodule WuunderUtils.Numbers do
   def as_string(nil), do: nil
 
   def as_string(value) when is_decimal(value), do: Decimal.to_string(value)
-  def as_string(value) when is_float(value), do: Float.to_string(value)
+
+  def as_string(value) when is_float(value),
+    do: :erlang.float_to_binary(value, [{:decimals, 4}, :compact])
+
   def as_string(value) when is_integer(value), do: Integer.to_string(value)
 
   def as_string(value) when is_binary(value) do


### PR DESCRIPTION
Because:
In our work we most often need Numbers.to_string return 3200.0 rather than `3.2e3`, therefore this change is closer to the expectation of developers

This commit:
Changes the output for `Numbers.to_string(3200.0)` from `"3.2e3"` to `"3200.0"`


* [x] Review required
* [x] Includes 1+ tests

